### PR TITLE
support CIFAR-10, CIFAR-10 datasets

### DIFF
--- a/lib/datasets.rb
+++ b/lib/datasets.rb
@@ -1,4 +1,5 @@
 require "datasets/version"
 
+require "datasets/cifar"
 require "datasets/iris"
 require "datasets/wikipedia"

--- a/lib/datasets/cifar.rb
+++ b/lib/datasets/cifar.rb
@@ -1,0 +1,89 @@
+require_relative "dataset"
+require "zlib"
+require 'rubygems/package'
+
+module Datasets
+  class Cifar < Dataset
+    Record = Struct.new(:sepal_length,
+                        :sepal_width,
+                        :petal_length,
+                        :petal_width,
+                        :class)
+
+    def initialize(class_num: 10, set_type: :train, with_label: true)
+      raise 'Please set class_num 10 or 100' unless [10, 100].include?(class_num)
+      super()
+      @metadata.name = "CIFAR-#{class_num}"
+      @metadata.url = "https://www.cs.toronto.edu/~kriz/cifar.html"
+      @metadata.description = "CIFAR-#{class_num} is 32x32 image datasets"
+
+      @class_num = class_num
+      @set_type = set_type.to_sym
+      @with_label = with_label
+    end
+
+    def each
+      return to_enum(__method__) unless block_given?
+
+      open_data do |raw|
+        yield(raw)
+      end
+    end
+
+    private 
+
+    def open_data
+      filename = "cifar-#{@class_num}.tar.gz"
+      compressed_file_path = cache_dir_path + filename
+      unless compressed_file_path.exist?
+        data_url = "https://www.cs.toronto.edu/~kriz/cifar-#{@class_num}-binary.tar.gz"
+        download(compressed_file_path, data_url)
+      end
+
+      if @class_num == 10
+        if @set_type == :train
+          file_names = ["data_batch_1.bin", "data_batch_2.bin", "data_batch_3.bin", "data_batch_4.bin", "data_batch_5.bin"]
+        elsif @set_type == :test
+          file_names = ["test_batch.bin"]
+        end
+
+        open_tar(compressed_file_path) do |tar|
+          file_names.each do |file_name|
+            entry = tar.find { |e| File.basename(e.full_name) == file_name }
+            while b = entry.read(3073) do
+              datasets = b.unpack("C*") 
+              label = datasets.shift
+              yield(@with_label ? [datasets, label] : datasets)
+            end
+            tar.rewind
+          end
+        end
+      elsif @class_num == 100
+        if @set_type == :train
+          file_name = "train.bin"
+        elsif @set_type == :test
+          file_name = "test.bin"
+        end
+
+        open_tar(compressed_file_path) do |tar|
+          entry = tar.find { |e| File.basename(e.full_name) == file_name }
+          while b = entry.read(3074) do
+            datasets = b.unpack("C*") 
+            # 0: coarse label, 1: fine label
+            labels = datasets.shift(2)
+            yield(@with_label ? [datasets, labels[1]] : datasets)
+          end
+        end
+      end
+    end
+
+    def open_tar(file_path)
+      Zlib::GzipReader.open(file_path) do |f|
+        Gem::Package::TarReader.new(f) do |tar|
+          yield(tar)
+        end
+      end
+    end
+  end
+end
+

--- a/lib/datasets/cifar.rb
+++ b/lib/datasets/cifar.rb
@@ -1,84 +1,90 @@
-require_relative "dataset"
+require "rubygems/package"
 require "zlib"
-require 'rubygems/package'
+
+require_relative "dataset"
 
 module Datasets
   class Cifar < Dataset
-    Record = Struct.new(:sepal_length,
-                        :sepal_width,
-                        :petal_length,
-                        :petal_width,
-                        :class)
+    Record = Struct.new(:data,
+                        :label)
 
-    def initialize(class_num: 10, set_type: :train, with_label: true)
+    def initialize(class_num: 10, set_type: :train)
       raise 'Please set class_num 10 or 100' unless [10, 100].include?(class_num)
+      raise 'Please set set_type :train or :test' unless [:train, :test].include?(set_type)
+ 
       super()
+
       @metadata.name = "CIFAR-#{class_num}"
       @metadata.url = "https://www.cs.toronto.edu/~kriz/cifar.html"
       @metadata.description = "CIFAR-#{class_num} is 32x32 image datasets"
 
       @class_num = class_num
-      @set_type = set_type.to_sym
-      @with_label = with_label
+      @set_type = set_type
     end
 
     def each
       return to_enum(__method__) unless block_given?
 
-      open_data do |raw|
-        yield(raw)
+      open_data do |row|
+        record = Record.new(*row)
+        yield(record)
       end
     end
 
     private 
 
     def open_data
-      filename = "cifar-#{@class_num}.tar.gz"
-      compressed_file_path = cache_dir_path + filename
-      unless compressed_file_path.exist?
+      data_path = cache_dir_path + "cifar-#{@class_num}.tar.gz"
+      unless data_path.exist?
         data_url = "https://www.cs.toronto.edu/~kriz/cifar-#{@class_num}-binary.tar.gz"
-        download(compressed_file_path, data_url)
+        download(data_path, data_url)
       end
 
-      if @class_num == 10
-        if @set_type == :train
-          file_names = ["data_batch_1.bin", "data_batch_2.bin", "data_batch_3.bin", "data_batch_4.bin", "data_batch_5.bin"]
-        elsif @set_type == :test
-          file_names = ["test_batch.bin"]
-        end
+      send("open_cifar#{@class_num}", data_path) do |data, label|
+        yield [data, label]
+      end
+    end
 
-        open_tar(compressed_file_path) do |tar|
-          file_names.each do |file_name|
-            entry = tar.find { |e| File.basename(e.full_name) == file_name }
-            while b = entry.read(3073) do
-              datasets = b.unpack("C*") 
-              label = datasets.shift
-              yield(@with_label ? [datasets, label] : datasets)
-            end
-            tar.rewind
-          end
-        end
-      elsif @class_num == 100
-        if @set_type == :train
-          file_name = "train.bin"
-        elsif @set_type == :test
-          file_name = "test.bin"
-        end
+    def open_cifar10(data_path)
+      if @set_type == :train
+        file_names = ["data_batch_1.bin", "data_batch_2.bin", "data_batch_3.bin", "data_batch_4.bin", "data_batch_5.bin"]
+      elsif @set_type == :test
+        file_names = ["test_batch.bin"]
+      end
 
-        open_tar(compressed_file_path) do |tar|
+      open_tar(data_path) do |tar|
+        file_names.each do |file_name|
           entry = tar.find { |e| File.basename(e.full_name) == file_name }
-          while b = entry.read(3074) do
+          while b = entry.read(3073) do
             datasets = b.unpack("C*") 
-            # 0: coarse label, 1: fine label
-            labels = datasets.shift(2)
-            yield(@with_label ? [datasets, labels[1]] : datasets)
+            label = datasets.shift
+            yield datasets, label
           end
+          tar.rewind
         end
       end
     end
 
-    def open_tar(file_path)
-      Zlib::GzipReader.open(file_path) do |f|
+    def open_cifar100(data_path)
+      if @set_type == :train
+        file_name = "train.bin"
+      elsif @set_type == :test
+        file_name = "test.bin"
+      end
+
+      open_tar(data_path) do |tar|
+        entry = tar.find { |e| File.basename(e.full_name) == file_name }
+        while b = entry.read(3074) do
+          datasets = b.unpack("C*") 
+          # 0: coarse label, 1: fine label
+          labels = datasets.shift(2)
+          yield datasets, labels[1]
+        end
+      end
+    end
+
+    def open_tar(data_path)
+      Zlib::GzipReader.open(data_path) do |f|
         Gem::Package::TarReader.new(f) do |tar|
           yield(tar)
         end

--- a/test/test-cifar.rb
+++ b/test/test-cifar.rb
@@ -1,0 +1,85 @@
+class CifarTest < Test::Unit::TestCase
+  sub_test_case("cifar-10") do
+    sub_test_case("train") do
+      def setup
+        @dataset = Datasets::Cifar.new(class_num: 10, set_type: :train)
+      end
+
+      test("#each") do
+        records = @dataset.to_a
+        assert_equal([
+                        50000,
+                        3072,
+                        Integer,
+                      ],
+                      [
+                        records.size,
+                        records[0].data.size,
+                        records[0].label.class
+                      ]) 
+      end
+    end
+
+    sub_test_case("test") do
+      def setup
+        @dataset = Datasets::Cifar.new(class_num: 10, set_type: :test)
+      end
+
+      test("#each") do
+        records = @dataset.to_a
+        assert_equal([
+                        10000,
+                        3072,
+                        Integer,
+                      ],
+                      [
+                        records.size,
+                        records[0].data.size,
+                        records[0].label.class
+                      ]) 
+      end
+    end
+  end
+  
+  sub_test_case("cifar-100") do
+    sub_test_case("train") do
+      def setup
+        @dataset = Datasets::Cifar.new(class_num: 100, set_type: :train)
+      end
+
+      test("#each") do
+        records = @dataset.to_a
+        assert_equal([
+                        50000,
+                        3072,
+                        Integer,
+                      ],
+                      [
+                        records.size,
+                        records[0].data.size,
+                        records[0].label.class
+                      ]) 
+      end
+    end
+
+    sub_test_case("test") do
+      def setup
+        @dataset = Datasets::Cifar.new(class_num: 100, set_type: :train)
+      end
+
+      test("#each") do
+        records = @dataset.to_a
+        assert_equal([
+                        10000,
+                        3072,
+                        Integer,
+                      ],
+                      [
+                        records.size,
+                        records[0].data.size,
+                        records[0].label.class
+                      ]) 
+      end
+    end
+  end
+end


### PR DESCRIPTION
add [CIFAR-10, 100](https://www.cs.toronto.edu/~kriz/cifar.html) datasets.

## Usage
### CIFAR1-10
```ruby
> require 'datasets'
> c = Datasets::Cifar.new
> c.metadata
# => #<struct Datasets::Metadata name="CIFAR-10", url="https://www.cs.toronto.edu/~kriz/cifar.html", licenses=nil, description="CIFAR-10 is 32x32 image datasets">
> c.each do |r|                                                                                                                                                        
    p r.data
    # => [59, 43, 50, 68, 98, 119, 139, 145, 149, 143, .....]
    p r.label
    # => 6
  end 
```

### CIFAR1-100
```ruby
> require 'datasets'
> c = Datasets::Cifar.new(class_num: 100)
> c.metadata
# => #<struct Datasets::Metadata name="CIFAR-100", url="https://www.cs.toronto.edu/~kriz/cifar.html", licenses=nil, description="CIFAR-100 is 32x32 image datasets">
> c.each do |r|                                                                                                                                                        
    p r.data
    # => [71, 74, 75, 76, 78, 81, 81, 78, ....]
    p r.label
    # => 23
  end 
```