### PR TITLE
Bump Ruby versions at Travis to its latest teeny versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ notifications:
 language: ruby
 
 rvm:
-  - 2.3.3
-  - 2.4.3
-  - 2.5.0
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
   - ruby-head
 
 cache:


### PR DESCRIPTION
This pull request bumps Ruby versions at Travis to its latest teeny versions.

* [Ruby 2.3.7 Released](https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-3-7-released/)
* [Ruby 2.4.4 Released](https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-4-4-released/)
* [Ruby 2.5.1 Released](https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-5-1-released/)

