### PR TITLE
Suppress Ruby 2.7 warnings

### DIFF
--- a/lib/datasets/adult.rb
+++ b/lib/datasets/adult.rb
@@ -62,11 +62,12 @@ module Datasets
         data_url = "http://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.#{ext}"
         download(data_path, data_url)
       end
-      CSV.open(data_path,
-               {
+
+      options = {
                  converters: [:numeric, lambda {|f| f.strip}],
                  skip_lines: /\A\|/,
-               }) do |csv|
+      }
+      CSV.open(data_path, **options) do |csv|
         yield(csv)
       end
     end


### PR DESCRIPTION
This pull request suppresses Ruby 2.7 warnings below.


```ruby
% ruby -v
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin19]
% rake test
/Users/yahonda/.rbenv/versions/2.7.0/bin/ruby test/run-test.rb
Loaded suite test
Started
./Users/yahonda/src/github.com/yahonda/red-datasets/lib/datasets/adult.rb:65: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/yahonda/.rbenv/versions/2.7.0/lib/ruby/2.7.0/csv.rb:635: warning: The called method `open' is defined here
```