### PR TITLE
Drop CI against Ruby 2.3 which already EOLed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ notifications:
 language: ruby
 
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6


### PR DESCRIPTION
* Support of Ruby 2.3 has ended
https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/