### PR TITLE
Add ::SeabornDataList

### DIFF
--- a/lib/datasets/seaborn-data.rb
+++ b/lib/datasets/seaborn-data.rb
@@ -1,4 +1,30 @@
 module Datasets
+  class SeabornDataList < Dataset
+    def initialize
+      super
+      @metadata.id = "seaborn-data-list"
+      @metadata.name = "SeabornDataList"
+      @metadata.url = "https://github.com/mwaskom/seaborn-data"
+      @metadata.licenses = nil
+      @metadata.description = "Datasets for seaborn examples."
+
+      @data_path = cache_dir_path / "index.html"
+    end
+
+    def each(&block)
+      return to_enum(__method__) unless block_given?
+
+      download(@data_path, @metadata.url)
+
+      regexp = %r{/mwaskom/seaborn-data/blob/master/(\w*).csv}
+      datasets = File.open(@data_path).read.scan(regexp)
+      datasets.each do |dataset_name|
+        record = {dataset: dataset_name[0]}
+        yield record
+      end
+    end
+  end
+
   class SeabornData < Dataset
     URL_FORMAT = "https://raw.githubusercontent.com/mwaskom/seaborn-data/master/%{name}.csv".freeze
 

--- a/test/test-seaborn-data.rb
+++ b/test/test-seaborn-data.rb
@@ -127,4 +127,20 @@ class SeabornDataTest < Test::Unit::TestCase
                   )
     end
   end
+
+  sub_test_case("dataset list") do
+    def setup
+      @dataset = Datasets::SeabornDataList.new
+    end
+
+    def test_each
+      table = @dataset.to_table
+      assert_equal(
+        [ "anagrams", "anscombe", "attention", "brain_networks", "car_crashes",
+          "diamonds", "dots", "exercise", "flights", "fmri", "gammas", "geyser",
+          "iris", "mpg", "penguins", "planets", "taxis", "tips", "titanic" ],
+        table.to_h[:dataset]
+      )
+    end
+  end 
 end

--- a/test/test-seaborn-data.rb
+++ b/test/test-seaborn-data.rb
@@ -1,4 +1,36 @@
 class SeabornDataTest < Test::Unit::TestCase
+  sub_test_case("list") do
+    def setup
+      @dataset = Datasets::SeabornDataList.new
+    end
+
+    def test_each
+      records = @dataset.each.to_a
+      assert_equal([
+                     {dataset: "anagrams"},
+                     {dataset: "anscombe"},
+                     {dataset: "attention"},
+                     {dataset: "brain_networks"},
+                     {dataset: "car_crashes"},
+                     {dataset: "diamonds"},
+                     {dataset: "dots"},
+                     {dataset: "exercise"},
+                     {dataset: "flights"},
+                     {dataset: "fmri"},
+                     {dataset: "gammas"},
+                     {dataset: "geyser"},
+                     {dataset: "iris"},
+                     {dataset: "mpg"},
+                     {dataset: "penguins"},
+                     {dataset: "planets"},
+                     {dataset: "taxis"},
+                     {dataset: "tips"},
+                     {dataset: "titanic"},
+                   ],
+                   records)
+    end
+  end
+
   sub_test_case("fmri") do
     def setup
       @dataset = Datasets::SeabornData.new("fmri")
@@ -127,20 +159,4 @@ class SeabornDataTest < Test::Unit::TestCase
                   )
     end
   end
-
-  sub_test_case("dataset list") do
-    def setup
-      @dataset = Datasets::SeabornDataList.new
-    end
-
-    def test_each
-      table = @dataset.to_table
-      assert_equal(
-        [ "anagrams", "anscombe", "attention", "brain_networks", "car_crashes",
-          "diamonds", "dots", "exercise", "flights", "fmri", "gammas", "geyser",
-          "iris", "mpg", "penguins", "planets", "taxis", "tips", "titanic" ],
-        table.to_h[:dataset]
-      )
-    end
-  end 
 end


### PR DESCRIPTION
(This is a splitted feature in #132)

`SeabornData` consists of 19 datasets but there is no dataset list now.
This PR is to introduce `SeabornDataList` class containing a list of datasets available.

Unfortunately data source has no `.csv` for summary, so the list is acquired from `.html` of data source directory.
This is a same way as original seaborn library is doing in `get_dataset_names()` method. 