### PR TITLE
Fix Rdatasets#each to change "NA" to nil

### DIFF
--- a/lib/datasets/rdatasets.rb
+++ b/lib/datasets/rdatasets.rb
@@ -85,10 +85,22 @@ module Datasets
       symbol_raw_converter = lambda do |header|
         header.encode(CSV::ConverterEncoding).to_sym
       end
-
+      na_converter = lambda do |field|
+        begin
+          if field.encode(CSV::ConverterEncoding) == "NA"
+            nil
+          else
+            field
+          end
+        rescue
+          field
+        end
+      end
       table = CSV.table(@data_path,
-                        header_converters: [symbol_raw_converter])
+                        header_converters: [symbol_raw_converter],
+                        converters: [na_converter, :all])
       table.delete(:"") # delete 1st column for indices.
+
       table.each do |row|
         yield row.to_h
       end

--- a/lib/datasets/rdatasets.rb
+++ b/lib/datasets/rdatasets.rb
@@ -82,13 +82,15 @@ module Datasets
       return to_enum(__method__) unless block_given?
 
       download(@data_path, @metadata.url)
-      CSV.open(@data_path, headers: :first_row, converters: :all) do |csv|
-        csv.each do |row|
-          record = row.to_h
-          record.delete("")
-          record.transform_keys!(&:to_sym)
-          yield record
-        end
+      symbol_raw_converter = lambda do |header|
+        header.encode(CSV::ConverterEncoding).to_sym
+      end
+
+      table = CSV.table(@data_path,
+                        header_converters: [symbol_raw_converter])
+      table.delete(:"") # delete 1st column for indices.
+      table.each do |row|
+        yield row.to_h
       end
     end
   end

--- a/test/test-rdatasets.rb
+++ b/test/test-rdatasets.rb
@@ -127,6 +127,50 @@ class RdatasetsTest < Test::Unit::TestCase
       end
     end
 
+    sub_test_case("airquality") do
+      def setup
+        @dataset = Datasets::Rdatasets.new("datasets", "airquality")
+      end
+
+      test("#each") do
+        records = @dataset.each.to_a
+        assert_equal([
+                       153,
+                       { Ozone: nil, "Solar.R": nil, Wind: 14.3, Temp: 56, Month: 5, Day: 5},
+                       { Ozone: 20, "Solar.R": 223, Wind: 11.5, Temp: 68, Month: 9, Day: 30},
+                     ],
+                     [
+                       records.size,
+                       records[4],
+                       records[-1]
+                     ])
+      end
+    end
+
+    sub_test_case('attenu') do
+      def setup
+        @dataset = Datasets::Rdatasets.new('datasets', 'attenu')
+      end
+
+      test('#each') do
+        records = @dataset.each.to_a
+        assert_equal([
+                       182,
+                       { event: 1, mag: 7, station: 117, dist: 12, accel: 0.359 },
+                       { event: 16, mag: 5.1, station: nil, dist: 7.6, accel: 0.28 },
+                       { event: 23, mag: 5.3, station: "c168", dist: 25.3, accel: 0.23 },
+                       { event: 23, mag: 5.3, station: 5072, dist: 53.1, accel: 0.022 }
+                     ],
+                     [
+                       records.size,
+                       records[0],
+                       records[78],
+                       records[169],
+                       records[-1]
+                     ])
+      end
+    end
+
     test("invalid package name") do
       assert_raise(ArgumentError) do
         Datasets::Rdatasets.new("invalid package name", "AirPassengers")


### PR DESCRIPTION
This pull request is a solution about #138 .

- First, introduce CSV#table to access by column later.
 
  This change is faster than before change.

```
$ bundle exec benchmark-driver benchmark_rdataset.yml

(snipped)
         original     21.516 i/s -      65.000 times in 3.021053s (46.48ms/i)
         new code     28.640 i/s -      90.000 times in 3.142489s (34.92ms/i)
```

benchmark_rdataset.yml
  ```
  prelude: |
    require 'datasets'
    dataset = Datasets::Rdatasets.new('datasets', 'quakes')

  benchmark:
    'new code': 'dataset.to_a'
  ```
