### PR TITLE
postal_code_japan: Fix zip url of romaji

### DIFF
--- a/lib/datasets/postal-code-japan.rb
+++ b/lib/datasets/postal-code-japan.rb
@@ -111,7 +111,7 @@ module Datasets
       when :uppercase
         data_url << "/oogaki/zip/ken_all.zip"
       when :romaji
-        data_url << "/roman/ken_all_rome.zip"
+        data_url << "/roman/naccs1.zip"
       end
       data_path = cache_dir_path + "#{@reading}-ken-all.zip"
       download(data_path, data_url)


### PR DESCRIPTION
zip download url has changed in Postal code japan - romaji.

https://www.post.japanpost.jp/zipcode/dl/roman-zip.html
