### PR TITLE
Fix errors in test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,37 @@
+PATH
+  remote: .
+  specs:
+    red-datasets (0.1.5)
+      csv (>= 3.0.5)
+      rexml
+      rubyzip
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    csv (3.2.3)
+    kramdown (2.4.0)
+      rexml
+    power_assert (2.0.1)
+    rake (13.0.6)
+    rexml (3.2.5)
+    rubyzip (2.3.2)
+    test-unit (3.5.3)
+      power_assert
+    webrick (1.7.0)
+    yard (0.9.28)
+      webrick (~> 1.7.0)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  bundler
+  kramdown
+  rake
+  red-datasets!
+  test-unit
+  yard
+
+BUNDLED WITH
+   2.3.16

--- a/lib/datasets/postal-code-japan.rb
+++ b/lib/datasets/postal-code-japan.rb
@@ -111,7 +111,7 @@ module Datasets
       when :uppercase
         data_url << "/oogaki/zip/ken_all.zip"
       when :romaji
-        data_url << "/roman/naccs1.zip"
+        data_url << "/roman/ken_all_rome.zip"
       end
       data_path = cache_dir_path + "#{@reading}-ken-all.zip"
       download(data_path, data_url)

--- a/test/test-rdatasets.rb
+++ b/test/test-rdatasets.rb
@@ -48,7 +48,7 @@ class RdatasetsTest < Test::Unit::TestCase
       test("without package_name") do
         records = @dataset.each.to_a
         assert_equal([
-                       1884,
+                       1892,
                        {
                          package: "AER",
                          dataset: "Affairs",

--- a/test/test-seaborn.rb
+++ b/test/test-seaborn.rb
@@ -17,7 +17,7 @@ class SeabornTest < Test::Unit::TestCase
                      {dataset: "exercise"},
                      {dataset: "flights"},
                      {dataset: "fmri"},
-                     {dataset: "gammas"},
+                     # {dataset: "gammas"}, # Removed Aug.15, 2022
                      {dataset: "geyser"},
                      {dataset: "iris"},
                      {dataset: "mpg"},

--- a/test/test-sudachi-synonym-dictionary.rb
+++ b/test/test-sudachi-synonym-dictionary.rb
@@ -6,7 +6,7 @@ class SudachiSynonymDictionaryTest < Test::Unit::TestCase
   test('#each') do
     records = @dataset.each.to_a
     assert_equal([
-                   65066,
+                   65182,
                    {
                      group_id: "000001",
                      is_noun: true,
@@ -19,15 +19,15 @@ class SudachiSynonymDictionaryTest < Test::Unit::TestCase
                      notation: "曖昧",
                    },
                    {
-                     group_id: "024892",
+                     group_id: "024909",
                      is_noun: true,
                      expansion_type: :expanded,
                      lexeme_id: 1,
                      form_type: :typical,
-                     acronym_type: :typical,
-                     variant_type: :alphabet,
-                     categories: ["教育"],
-                     notation: "gymnasium",
+                     acronym_type: :alphabet,
+                     variant_type: :typical,
+                     categories: ["ビジネス"],
+                     notation: "BPO",
                    },
                  ],
                  [


### PR DESCRIPTION
Now the test has 3 Failures and 1 Error.
This request will fix them.

## Revert "postalcodejapan: Fix zip url of romaji (#141)"

This reverts commit 7aeefd82c899afb69eb7494c7ac42905338f6170 (#141).

Source data has reverted to previous zip file name.
https://www.post.japanpost.jp/zipcode/dl/roman-zip.html
