### PR TITLE
prefer XDG_CACHE_HOME before os specific cache directories

### DIFF
--- a/lib/datasets/cache-path.rb
+++ b/lib/datasets/cache-path.rb
@@ -15,13 +15,14 @@ module Datasets
     private
 
     def system_cache_dir
+      return ENV['XDG_CACHE_HOME'] if ENV['XDG_CACHE_HOME']
       case RUBY_PLATFORM
       when /mswin/, /mingw/
         ENV['LOCALAPPDATA'] || '~/AppData/Local'
       when /darwin/
         '~/Library/Caches'
       else
-        ENV['XDG_CACHE_HOME'] || '~/.cache'
+        '~/.cache'
       end
     end
   end


### PR DESCRIPTION
I think the correct logic is to use XDG_CACHE_HOME if it is given and if not, use platform defaults