### PR TITLE
test cldr, geolonia, rdataset: update expected

### DIFF
--- a/test/test-cldr-plurals.rb
+++ b/test/test-cldr-plurals.rb
@@ -14,7 +14,7 @@ class CLDRPluralsTest < Test::Unit::TestCase
   test("#each") do
     locales = @dataset.each.to_a
     assert_equal([
-                   219,
+                   220,
                    locale("bm",
                           [
                             rule("other",

--- a/test/test-geolonia.rb
+++ b/test/test-geolonia.rb
@@ -6,7 +6,7 @@ class GeoloniaTest < Test::Unit::TestCase
   test('#each') do
     records = @dataset.each.to_a
     assert_equal([
-                   277616,
+                   277656,
                    {
                      :prefecture_code => "01",
                      :prefecture_name => "北海道",

--- a/test/test-rdataset.rb
+++ b/test/test-rdataset.rb
@@ -8,7 +8,7 @@ class RdatasetTest < Test::Unit::TestCase
       test("with package_name") do
         records = @dataset.filter(package: "datasets").to_a
         assert_equal([
-                       102,
+                       104,
                        {
                          package: "datasets",
                          dataset: "ability.cov",
@@ -48,7 +48,7 @@ class RdatasetTest < Test::Unit::TestCase
       test("without package_name") do
         records = @dataset.each.to_a
         assert_equal([
-                       2142,
+                       2264,
                        {
                          package: "AER",
                          dataset: "Affairs",
@@ -110,8 +110,8 @@ class RdatasetTest < Test::Unit::TestCase
           records = @dataset.each.to_a
           assert_equal([
                          144,
-                         { time: 1949,             value: 112 },
-                         { time: 1960.91666666667, value: 432 },
+                         { time: 1949,             value: 112, rownames: 1 },
+                         { time: 1960.91666666667, value: 432, rownames: 144 },
                        ],
                        [
                          records.size,
@@ -141,8 +141,8 @@ class RdatasetTest < Test::Unit::TestCase
           records = @dataset.each.to_a
           assert_equal([
                          153,
-                         { Ozone: nil, "Solar.R": nil, Wind: 14.3, Temp: 56, Month: 5, Day: 5 },
-                         { Ozone: 20, "Solar.R": 223, Wind: 11.5, Temp: 68, Month: 9, Day: 30 },
+                         { Ozone: nil, "Solar.R": nil, Wind: 14.3, Temp: 56, Month: 5, Day: 5, rownames: 5 },
+                         { Ozone: 20, "Solar.R": 223, Wind: 11.5, Temp: 68, Month: 9, Day: 30, rownames: 153 },
                        ],
                        [
                          records.size,
@@ -161,10 +161,10 @@ class RdatasetTest < Test::Unit::TestCase
           records = @dataset.each.to_a
           assert_equal([
                          182,
-                         { event: 1, mag: 7, station: "117", dist: 12, accel: 0.359 },
-                         { event: 16, mag: 5.1, station: nil, dist: 7.6, accel: 0.28 },
-                         { event: 23, mag: 5.3, station: "c168", dist: 25.3, accel: 0.23 },
-                         { event: 23, mag: 5.3, station: "5072", dist: 53.1, accel: 0.022 }
+                         { event: 1, mag: 7, station: 117, dist: 12, accel: 0.359, rownames: 1 },
+                         { event: 16, mag: 5.1, station: nil, dist: 7.6, accel: 0.28, rownames: 79 },
+                         { event: 23, mag: 5.3, station: "c168", dist: 25.3, accel: 0.23, rownames: 170 },
+                         { event: 23, mag: 5.3, station: 5072, dist: 53.1, accel: 0.022, rownames: 182 }
                        ],
                        [
                          records.size,
@@ -187,8 +187,8 @@ class RdatasetTest < Test::Unit::TestCase
           records = @dataset.each.to_a
           assert_equal([
                          192,
-                         { temp: 10, species: 'wheat', start: 0, end: 1.0, germinated: 0 },
-                         { temp: 40, species: 'rice', start: 18, end: Float::INFINITY, germinated: 12 }
+                         { temp: 10, species: 'wheat', start: 0, end: 1, germinated: 0, rownames: 1 },
+                         { temp: 40, species: 'rice', start: 18, end: Float::INFINITY, germinated: 12, rownames: 192 }
                        ],
                        [
                          records.size,
@@ -213,25 +213,27 @@ class RdatasetTest < Test::Unit::TestCase
                           Order: 398_481,
                           Level: 1,
                           Code: 'A',
-                          Parent: '',
+                          Parent: nil,
                           Description: 'AGRICULTURE, FORESTRY AND FISHING',
                           This_item_includes: 'This section includes the exploitation of vegetal and animal natural resources, comprising the activities of growing of crops, raising and breeding of animals, harvesting of timber and other plants, animals or animal products from a farm or their natural habitats.',
-                          This_item_also_includes: '',
-                          Rulings: '',
-                          This_item_excludes: '',
-                          "Reference_to_ISIC_Rev._4": 'A'
+                          This_item_also_includes: nil,
+                          Rulings: nil,
+                          This_item_excludes: nil,
+                          "Reference_to_ISIC_Rev._4": 'A',
+                          rownames: 1
                         },
                         {
                           Order: 399_476,
                           Level: 4,
-                          Code: '99.00',
-                          Parent: '99.0',
+                          Code: 99.0,
+                          Parent: 99.0,
                           Description: 'Activities of extraterritorial organisations and bodies',
                           This_item_includes: "This class includes:\n- activities of international organisations such as the United Nations and the specialised agencies of the United Nations system, regional bodies etc., the International Monetary Fund, the World Bank, the World Customs Organisation, the Organisation for Economic Co-operation and Development, the organisation of Petroleum Exporting Countries, the European Communities, the European Free Trade Association etc.",
                           This_item_also_includes: "This class also includes:\n- activities of diplomatic and consular missions when being determined by the country of their location rather than by the country they represent",
-                          Rulings: '',
-                          This_item_excludes: '',
-                          "Reference_to_ISIC_Rev._4": '9900'
+                          Rulings: nil,
+                          This_item_excludes: nil,
+                          "Reference_to_ISIC_Rev._4": 9900,
+                          rownames: 996
                         }
                       ],
                       [


### PR DESCRIPTION
Rationale for this change
---

Following tests are fail because available datasets have been updated.

- CLDR language plural rules
- Geolonia
- Rdataset

What changes are included in this PR?
---

Update expected. But postal code japan of test is still error. It fixes 4b1d568 on next PR.