### PR TITLE
test postal code japan: modify the downloaded URL

### DIFF
--- a/lib/datasets/postal-code-japan.rb
+++ b/lib/datasets/postal-code-japan.rb
@@ -111,7 +111,7 @@ module Datasets
       when :uppercase
         data_url << "/oogaki/zip/ken_all.zip"
       when :romaji
-        data_url << "/roman/ken_all_rome.zip"
+        data_url << "/roman/KEN_ALL_ROME.zip"
       end
       data_path = cache_dir_path + "#{@reading}-ken-all.zip"
       download(data_path, data_url)


### PR DESCRIPTION
Rationale for this change
---

Unable to download `ken_all_rome.zip` for the test of postal code in
Japan because the downloaded URL is `ken_all_rome.zip`, not
`KEN_ALL_ROME.zip`. It has been modified below.

https://www.post.japanpost.jp/zipcode/dl/roman-zip.html

What changes are included
---

Modify the downloaded URL.