### PR TITLE
mnist: use mirror only when original server is not available

### DIFF
--- a/lib/datasets/dataset.rb
+++ b/lib/datasets/dataset.rb
@@ -35,15 +35,16 @@ module Datasets
 
     def download(output_path, url, *fallback_urls, &block)
       urls = [url] + fallback_urls
-      urls.each do |url|
+      urls.each_with_index do |url, idx|
         downloader = Downloader.new(url)
         downloader.download(output_path, &block)
         return
       rescue Net::HTTPClientException => error
         if urls.last != url
-          message = "site is not available: " +
-                    "#{error.class}: #{error.message}: " +
-                    "Attempting to download from an alternative site"
+          failed_message = "failed to download: #{url}"
+          fallback_message = "fallback to: #{urls[idx + 1]}"
+          message = "#{error.response.code} #{error.response.message}: " +
+                    "#{failed_message} .. #{fallback_message}"
           $stderr.puts(message)
         else
           raise error

--- a/lib/datasets/dataset.rb
+++ b/lib/datasets/dataset.rb
@@ -34,22 +34,8 @@ module Datasets
     end
 
     def download(output_path, url, *fallback_urls, &block)
-      urls = [url] + fallback_urls
-      urls.each_with_index do |url, index|
-        downloader = Downloader.new(url)
-        downloader.download(output_path, &block)
-        return
-      rescue Net::HTTPClientException => error
-        if urls.last != url
-          failed_url = url
-          fallback_url = urls[index + 1]
-          message = "#{error.response.code} #{error.response.message}: " +
-                    "fallback: <#{failed_url}> -> <#{fallback_url}>"
-          $stderr.puts(message)
-        else
-          raise
-        end
-      end
+      downloader = Downloader.new(url, *fallback_urls)
+      downloader.download(output_path, &block)
     end
 
     def extract_bz2(bz2)

--- a/lib/datasets/dataset.rb
+++ b/lib/datasets/dataset.rb
@@ -33,7 +33,8 @@ module Datasets
       @cache_path ||= CachePath.new(@metadata.id)
     end
 
-    def download(output_path, *urls, &block)
+    def download(output_path, url, *fallback_urls, &block)
+      urls = [url] + fallback_urls
       urls.each do |url|
         downloader = Downloader.new(url)
         downloader.download(output_path, &block)

--- a/lib/datasets/dataset.rb
+++ b/lib/datasets/dataset.rb
@@ -41,10 +41,10 @@ module Datasets
         return
       rescue Net::HTTPClientException => error
         if urls.last != url
-          failed_url = "<#{url}>"
-          fallback_url = "<#{urls[index + 1]}>"
+          failed_url = url
+          fallback_url = urls[index + 1]
           message = "#{error.response.code} #{error.response.message}: " +
-                    "fallback: #{failed_url} -> #{fallback_url}"
+                    "fallback: <#{failed_url}> -> <#{fallback_url}>"
           $stderr.puts(message)
         else
           raise error

--- a/lib/datasets/dataset.rb
+++ b/lib/datasets/dataset.rb
@@ -35,14 +35,14 @@ module Datasets
 
     def download(output_path, url, *fallback_urls, &block)
       urls = [url] + fallback_urls
-      urls.each_with_index do |url, idx|
+      urls.each_with_index do |url, index|
         downloader = Downloader.new(url)
         downloader.download(output_path, &block)
         return
       rescue Net::HTTPClientException => error
         if urls.last != url
           failed_url = "<#{url}>"
-          fallback_url = "<#{urls[idx + 1]}>"
+          fallback_url = "<#{urls[index + 1]}>"
           message = "#{error.response.code} #{error.response.message}: " +
                     "fallback: #{failed_url} -> #{fallback_url}"
           $stderr.puts(message)

--- a/lib/datasets/dataset.rb
+++ b/lib/datasets/dataset.rb
@@ -33,9 +33,21 @@ module Datasets
       @cache_path ||= CachePath.new(@metadata.id)
     end
 
-    def download(output_path, url, &block)
-      downloader = Downloader.new(url)
-      downloader.download(output_path, &block)
+    def download(output_path, *urls, &block)
+      urls.each do |url|
+        downloader = Downloader.new(url)
+        downloader.download(output_path, &block)
+        return
+      rescue Net::HTTPClientException => error
+        if urls.last != url
+          message = "site is not available: " +
+                    "#{error.class}: #{error.message}: " +
+                    "Attempting to download from an alternative site"
+          $stderr.puts(message)
+        else
+          raise error
+        end
+      end
     end
 
     def extract_bz2(bz2)

--- a/lib/datasets/dataset.rb
+++ b/lib/datasets/dataset.rb
@@ -47,7 +47,7 @@ module Datasets
                     "fallback: <#{failed_url}> -> <#{fallback_url}>"
           $stderr.puts(message)
         else
-          raise error
+          raise
         end
       end
     end

--- a/lib/datasets/dataset.rb
+++ b/lib/datasets/dataset.rb
@@ -41,10 +41,10 @@ module Datasets
         return
       rescue Net::HTTPClientException => error
         if urls.last != url
-          failed_message = "failed to download: #{url}"
-          fallback_message = "fallback to: #{urls[idx + 1]}"
+          failed_url = "<#{url}>"
+          fallback_url = "<#{urls[idx + 1]}>"
           message = "#{error.response.code} #{error.response.message}: " +
-                    "#{failed_message} .. #{fallback_message}"
+                    "fallback: #{failed_url} -> #{fallback_url}"
           $stderr.puts(message)
         else
           raise error

--- a/lib/datasets/downloader.rb
+++ b/lib/datasets/downloader.rb
@@ -161,7 +161,9 @@ module Datasets
             return start_http(url, headers, limit - 1, &block)
           else
             if response.is_a?(Net::HTTPForbidden)
-              fallback_url = @fallback_urls.shift
+              index = @fallback_urls.index(url)
+              fallback_index = index.nil? ? 0 : index + 1
+              fallback_url = @fallback_urls[fallback_index]
               unless fallback_url.nil?
                 message = "#{response.code}: #{response.message}: " +
                           "fallback: <#{url}> -> <#{fallback_url}>"

--- a/lib/datasets/downloader.rb
+++ b/lib/datasets/downloader.rb
@@ -13,15 +13,7 @@ module Datasets
     class TooManyRedirects < Error; end
 
     def initialize(url)
-      if url.is_a?(URI::Generic)
-        url = url.dup
-      else
-        url = URI.parse(url)
-      end
-      @url = url
-      unless @url.is_a?(URI::HTTP)
-        raise ArgumentError, "download URL must be HTTP or HTTPS: <#{@url}>"
-      end
+      @url = normalize_url(url)
     end
 
     def download(output_path, &block)
@@ -85,6 +77,18 @@ module Datasets
           raise TooManyRedirects, "too many redirections: #{@url} .. #{last_url}"
         end
       end
+    end
+
+    private def normalize_url(url)
+      if url.is_a?(URI::Generic)
+        url = url.dup
+      else
+        url = URI.parse(url)
+      end
+      unless url.is_a?(URI::HTTP)
+        raise ArgumentError, "download URL must be HTTP or HTTPS: <#{url}>"
+      end
+      url
     end
 
     private def synchronize(output_path, partial_output_path)

--- a/lib/datasets/fashion-mnist.rb
+++ b/lib/datasets/fashion-mnist.rb
@@ -2,9 +2,13 @@ require_relative 'mnist'
 
 module Datasets
   class FashionMNIST < MNIST
-    BASE_URL = "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/"
-
     private
+    def base_urls
+      [
+        "http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/",
+      ]
+    end
+
     def dataset_name
       "Fashion-MNIST"
     end

--- a/lib/datasets/kuzushiji-mnist.rb
+++ b/lib/datasets/kuzushiji-mnist.rb
@@ -2,9 +2,13 @@ require_relative 'mnist'
 
 module Datasets
   class KuzushijiMNIST < MNIST
-    BASE_URL = "http://codh.rois.ac.jp/kmnist/dataset/kmnist/"
-
     private
+    def base_urls
+      [
+        "http://codh.rois.ac.jp/kmnist/dataset/kmnist/",
+      ]
+    end
+
     def dataset_name
       "Kuzushiji-MNIST"
     end

--- a/lib/datasets/mnist.rb
+++ b/lib/datasets/mnist.rb
@@ -42,27 +42,11 @@ module Datasets
 
       image_path = cache_dir_path + target_file(:image)
       label_path = cache_dir_path + target_file(:label)
-      base_url = base_urls.first
-      fallback_url = base_urls.second
 
-      begin
-        download(image_path, base_url + target_file(:image))
-      rescue Net::HTTPClientException => error
-        if error.response.code == "403"
-          download(image_path, fallback_url + target_file(:image))
-        else
-          raise error
-        end
-      end
-      begin
-        download(label_path, base_url + target_file(:label))
-      rescue Net::HTTPClientException => error
-        if error.response.code == "403"
-          download(label_path, fallback_url + target_file(:label))
-        else
-          raise error
-        end
-      end
+      download(image_path,
+               *base_urls.collect { |base_url| base_url + target_file(:image) })
+      download(label_path,
+               *base_urls.collect { |base_url| base_url + target_file(:label) })
 
       open_data(image_path, label_path, &block)
     end

--- a/lib/datasets/mnist.rb
+++ b/lib/datasets/mnist.rb
@@ -4,9 +4,6 @@ require_relative "dataset"
 
 module Datasets
   class MNIST < Dataset
-    BASE_URL = "http://yann.lecun.com/exdb/mnist/"
-    FALLBACK_URL = "https://ossci-datasets.s3.amazonaws.com/mnist/"
-
     class Record < Struct.new(:data, :label)
       def pixels
         data.unpack("C*")
@@ -28,7 +25,7 @@ module Datasets
 
       @metadata.id = "#{dataset_name.downcase}-#{type}"
       @metadata.name = "#{dataset_name}: #{type}"
-      @metadata.url = self.class::BASE_URL
+      @metadata.url = base_urls.first
       @metadata.licenses = licenses
       @type = type
 
@@ -45,8 +42,8 @@ module Datasets
 
       image_path = cache_dir_path + target_file(:image)
       label_path = cache_dir_path + target_file(:label)
-      base_url = self.class::BASE_URL
-      fallback_url = self.class::FALLBACK_URL
+      base_url = base_urls.first
+      fallback_url = base_urls.second
 
       begin
         download(image_path, base_url + target_file(:image))
@@ -71,6 +68,13 @@ module Datasets
     end
 
     private
+    def base_urls
+      [
+        "http://yann.lecun.com/exdb/mnist/",
+        "https://ossci-datasets.s3.amazonaws.com/mnist/",
+      ]
+    end
+
     def licenses
       []
     end

--- a/test/test-downloader.rb
+++ b/test/test-downloader.rb
@@ -17,7 +17,7 @@ class DownloaderTest < Test::Unit::TestCase
       output_path = @tmp_dir + "file"
       downloader = Datasets::Downloader.new(first_url)
 
-      downloader.define_singleton_method(:start_http) do |url, headers|
+      downloader.define_singleton_method(:start_http) do |url, fallback_urls, headers|
         raise Datasets::Downloader::TooManyRedirects, "too many redirections: #{last_url}"
       end
 


### PR DESCRIPTION
MNIST's original server is sometimes refusing to provide the requested
resource. So, we use the mirror server only when the original server is
refusing it.

Moreover this includes the following changes.

- Support fallback in Downloader

Fixes GH-195.
