### PR TITLE
Revert "wikipedia-kyoto-japanese-english: increase REXML entity expansion limit during XML parsing (#198)

### DIFF
--- a/lib/datasets/wikipedia-kyoto-japanese-english.rb
+++ b/lib/datasets/wikipedia-kyoto-japanese-english.rb
@@ -89,9 +89,7 @@ articles (related to Kyoto) into English.
             next unless base_name.end_with?(".xml")
             listener = ArticleListener.new(block)
             parser = REXML::Parsers::StreamParser.new(entry.read, listener)
-            with_increased_entity_expansion_text_limit do
-              parser.parse
-            end
+            parser.parse
           when :lexicon
             next unless base_name == "kyoto_lexicon.csv"
             is_header = true
@@ -108,23 +106,12 @@ articles (related to Kyoto) into English.
     end
 
     private
-
-    ENTITY_EXPANSION_TEXT_LIMIT = 163_840
-
     def download_tar_gz
       base_name = "wiki_corpus_2.01.tar.gz"
       data_path = cache_dir_path + base_name
       data_url = "https://alaginrc.nict.go.jp/WikiCorpus/src/#{base_name}"
       download(data_path, data_url)
       data_path
-    end
-
-    def with_increased_entity_expansion_text_limit
-      default_limit = REXML::Security.entity_expansion_text_limit
-      REXML::Security.entity_expansion_text_limit = ENTITY_EXPANSION_TEXT_LIMIT
-      yield
-    ensure
-      REXML::Security.entity_expansion_text_limit = default_limit
     end
 
     class ArticleListener


### PR DESCRIPTION


This reverts commit a76b9176f88ce3248e5f97867088bec29ed521cc.

REXML has fixed the bug where `REXML::Security.entity_expansion_text_limit` incorrectly calculated text size in both SAX and pull parsers. Therefore, we no longer need to handle this issue within Red Datasets.

ref: https://github.com/ruby/rexml/releases/tag/v3.3.5