### PR TITLE
test geolonia: reduce checking

### DIFF
--- a/test/test-geolonia.rb
+++ b/test/test-geolonia.rb
@@ -4,47 +4,23 @@ class GeoloniaTest < Test::Unit::TestCase
   end
 
   test('#each') do
-    records = @dataset.each.to_a
-    assert_equal([
-                   277656,
-                   {
-                     :prefecture_code => "01",
-                     :prefecture_name => "北海道",
-                     :prefecture_kana => "ホッカイドウ",
-                     :prefecture_romaji => "HOKKAIDO",
-                     :municipality_code => "01101",
-                     :municipality_name => "札幌市中央区",
-                     :municipality_kana => "サッポロシチュウオウク",
-                     :municipality_romaji => "SAPPORO SHI CHUO KU",
-                     :street_name => "旭ケ丘一丁目",
-                     :street_kana => "アサヒガオカ 1",
-                     :street_romaji => "ASAHIGAOKA 1",
-                     :alias => nil,
-                     :latitude => "43.04223",
-                     :longitude => "141.319722"
-                   },
-                   {
-                     :prefecture_code => "47",
-                     :prefecture_name => "沖縄県",
-                     :prefecture_kana => "オキナワケン",
-                     :prefecture_romaji => "OKINAWA KEN",
-                     :municipality_code => "47382",
-                     :municipality_name => "八重山郡与那国町",
-                     :municipality_kana => "ヤエヤマグンヨナグニチョウ",
-                     :municipality_romaji => "YAEYAMA GUN YONAGUNI CHO",
-                     :street_name => "字与那国",
-                     :street_kana => nil,
-                     :street_romaji => nil,
-                     :alias => nil,
-                     :latitude => "24.455925",
-                     :longitude => "122.987678",
-                   },
-                 ],
-                 [
-                   records.size,
-                   records[0].to_h,
-                   records[-1].to_h,
-                 ])
+    assert_equal({
+                   :prefecture_code => "01",
+                   :prefecture_name => "北海道",
+                   :prefecture_kana => "ホッカイドウ",
+                   :prefecture_romaji => "HOKKAIDO",
+                   :municipality_code => "01101",
+                   :municipality_name => "札幌市中央区",
+                   :municipality_kana => "サッポロシチュウオウク",
+                   :municipality_romaji => "SAPPORO SHI CHUO KU",
+                   :street_name => "旭ケ丘一丁目",
+                   :street_kana => "アサヒガオカ 1",
+                   :street_romaji => "ASAHIGAOKA 1",
+                   :alias => nil,
+                   :latitude => "43.04223",
+                   :longitude => "141.319722",
+                 },
+                 @dataset.each.next.to_h)
   end
 
   sub_test_case("#metadata") do


### PR DESCRIPTION
GitHub: GH-188

Because csv file is too big (277,656 rows).

Before this change:

```console
$ time ruby test/run-test.rb -t GeoloniaTest --verbose=important-only
Finished in 5.998956 seconds.
2 tests, 2 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0
notifications

real    0m6.603s
user    0m6.146s
sys     0m0.346s
```

After this change:

```console
$ time ruby test/run-test.rb -t GeoloniaTest --verbose=important-only
Finished in 0.001634 seconds.
2 tests, 2 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0
notifications

real    0m0.564s
user    0m0.388s
sys     0m0.087s
```