### PR TITLE
test diamonds: reduce needless converters

### DIFF
--- a/lib/datasets/ggplot2-dataset.rb
+++ b/lib/datasets/ggplot2-dataset.rb
@@ -17,7 +17,7 @@ module Datasets
       data_path = cache_dir_path + data_base_name
       data_url = "#{download_base_url}/data-raw/#{data_base_name}"
       download(data_path, data_url)
-      CSV.open(data_path, headers: :first_row, converters: :all) do |csv|
+      CSV.open(data_path, headers: :first_row, converters: :numeric) do |csv|
         record_class = self.class::Record
         csv.each do |row|
           record = record_class.new(*row.fields)


### PR DESCRIPTION
GitHub: GH-188

Because date_time is not included in the following csvs.

* diamonds.csv (diamonds dataset inherits from `Ggplot2Dataset`)
* mpg.csv (fuel economy dataset inherits from `Ggplot2Dataset`)

Before this change:

```console
$ time ruby test/run-test.rb -t DiamondsTest --verbose=important-only
Finished in 3.702616 seconds.
2 tests, 2 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0
notifications

real    0m4.665s
user    0m4.136s
sys     0m0.226s
```

After this change:

```console
$ time ruby test/run-test.rb -t DiamondsTest --verbose=important-only
Finished in 3.367821 seconds.
2 tests, 2 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0
notifications

real    0m4.179s
user    0m3.738s
sys     0m0.202s
```

After this change, the fuel economy dataset test also passed:

```console
$ ruby test/run-test.rb -t FuelEconomyTest --verbose=important-only
Finished in 0.017332 seconds.
2 tests, 2 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
```