### PR TITLE
test diamonds: reduce checking

### DIFF
--- a/test/test-diamonds.rb
+++ b/test/test-diamonds.rb
@@ -8,39 +8,19 @@ class DiamondsTest < Test::Unit::TestCase
   end
 
   test("#each") do
-    records = @dataset.each.to_a
-    assert_equal([
-                   53940,
-                   {
-                     carat: 0.23,
-                     clarity: "SI2",
-                     color: "E",
-                     cut: "Ideal",
-                     depth: 61.5,
-                     price: 326,
-                     table: 55.0,
-                     x: 3.95,
-                     y: 3.98,
-                     z: 2.43,
-                   },
-                   {
-                     carat: 0.75,
-                     clarity: "SI2",
-                     color: "D",
-                     cut: "Ideal",
-                     depth: 62.2,
-                     price: 2757,
-                     table: 55.0,
-                     x: 5.83,
-                     y: 5.87,
-                     z: 3.64,
-                   },
-                 ],
-                 [
-                   records.size,
-                   records[0].to_h,
-                   records[-1].to_h
-                 ])
+    assert_equal({
+                   carat: 0.23,
+                   clarity: "SI2",
+                   color: "E",
+                   cut: "Ideal",
+                   depth: 61.5,
+                   price: 326,
+                   table: 55.0,
+                   x: 3.95,
+                   y: 3.98,
+                   z: 2.43,
+                 },
+                 @dataset.each.next.to_h)
   end
 
   sub_test_case("#metadata") do


### PR DESCRIPTION
GitHub: GH-188

Because csv file is too big (53,940 rows).

Before this change:

```console
$ time ruby test/run-test.rb -t DiamondsTest --verbose=important-only
Finished in 3.367821 seconds.
2 tests, 2 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0
notifications

real    0m4.179s
user    0m3.738s
sys     0m0.202s
```

After this change:

```console
$ time ruby test/run-test.rb -t DiamondsTest --verbose=important-only
Finished in 0.002048 seconds.
2 tests, 2 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0
notifications

real    0m0.551s
user    0m0.379s
sys     0m0.085s
```