### PR TITLE
california-housing: suppress "literal string will be frozen in the future" warning

### DIFF
--- a/lib/datasets/california-housing.rb
+++ b/lib/datasets/california-housing.rb
@@ -36,7 +36,7 @@ Available from http://lib.stat.cmu.edu/datasets/.
       file_name = "cadata.txt"
       download(data_path, data_url)
       open_data(data_path, file_name) do |input|
-        data = ""
+        data = +""
         input.each_line do |line|
           next unless line.start_with?(" ")
           data << line.lstrip.gsub(/ +/, ",")


### PR DESCRIPTION
Before change:

```console
$ ruby test/run-test.rb -t CaliforniaHousingTest 2>&1 | grep red-datasets
/Users/zzz/src/github.com/red-data-tools/red-datasets/lib/datasets/california-housing.rb:42:
warning: literal string will be frozen in the future
```

After change:

```console
$ ruby test/run-test.rb -t CaliforniaHousingTest 2>&1 | grep red-datasets
```