### PR TITLE
diamonds, fuel-economy: suppress "literal string will be frozen in the future" warning

### DIFF
--- a/lib/datasets/ggplot2-dataset.rb
+++ b/lib/datasets/ggplot2-dataset.rb
@@ -37,7 +37,7 @@ module Datasets
       data_r_url = "#{download_base_url}/R/#{data_r_base_name}"
       download(data_r_path, data_r_url)
       descriptions = {}
-      comment = ""
+      comment = +""
       File.open(data_r_path) do |data_r|
         data_r.each_line do |line|
           case line.chomp
@@ -51,7 +51,7 @@ module Datasets
           when /\A"(.+)"\z/
             name = Regexp.last_match[1]
             descriptions[name] = parse_roxygen(comment.rstrip)
-            comment = ""
+            comment = +""
           end
         end
         descriptions[@ggplot2_dataset_name]


### PR DESCRIPTION
Before change:

```console
$ ruby test/run-test.rb -t '/DiamondsTest|FuelEconomyTest/' 2>&1 | grep red-datasets
/Users/zzz/src/github.com/red-data-tools/red-datasets/lib/datasets/ggplot2-dataset.rb:49: warning: literal string will be frozen in the future
(repeated 29 times)
```

After change:

```console
$ ruby test/run-test.rb -t '/DiamondsTest|FuelEconomyTest/' 2>&1 | grep red-datasets
```