### PR TITLE
test house-of-councillor: add a test for invalid type

### DIFF
--- a/test/test-house-of-councillor.rb
+++ b/test/test-house-of-councillor.rb
@@ -1,4 +1,11 @@
 class HouseOfCouncillorTest < Test::Unit::TestCase
+  test("invalid") do
+    message = ":type must be one of [:bill, :in_house_group, :member, :question]: :invalid"
+    assert_raise(ArgumentError.new(message)) do
+      Datasets::HouseOfCouncillor.new(type: :invalid)
+    end
+  end
+
   sub_test_case(":bill") do
     def setup
       @dataset = Datasets::HouseOfCouncillor.new


### PR DESCRIPTION
Because verify "literal string will be frozen in the future" warning.