### PR TITLE
house-of-councillor: suppress "literal string will be frozen in the future" warning

### DIFF
--- a/lib/datasets/house-of-councillor.rb
+++ b/lib/datasets/house-of-councillor.rb
@@ -104,7 +104,7 @@ module Datasets
       super()
       @type = type
       unless VALID_TYPES.include?(type)
-        message = ":type must be one of ["
+        message = +":type must be one of ["
         message << VALID_TYPES.collect(&:inspect).join(", ")
         message << "]: #{@type.inspect}"
         raise ArgumentError, message
@@ -143,7 +143,7 @@ module Datasets
     private
 
     def open_data
-      data_url = "https://smartnews-smri.github.io/house-of-councillors/data"
+      data_url = +"https://smartnews-smri.github.io/house-of-councillors/data"
       case @type
       when :bill
         data_url << "/gian.csv"


### PR DESCRIPTION
Before change:

```console
$ ruby test/run-test.rb -t HouseOfCouncillorTest 2>&1 | grep red-datasets
/Users/zzz/src/github.com/red-data-tools/red-datasets/lib/datasets/house-of-councillor.rb:108: warning: literal string will be frozen in the future
/Users/zzz/src/github.com/red-data-tools/red-datasets/lib/datasets/house-of-councillor.rb:149: warning: literal string will be frozen in the future
/Users/zzz/src/github.com/red-data-tools/red-datasets/lib/datasets/house-of-councillor.rb:151: warning: literal string will be frozen in the future
/Users/zzz/src/github.com/red-data-tools/red-datasets/lib/datasets/house-of-councillor.rb:153: warning: literal string will be frozen in the future
/Users/zzz/src/github.com/red-data-tools/red-datasets/lib/datasets/house-of-councillor.rb:155: warning: literal string will be frozen in the future
```

After change:

```console
$ ruby test/run-test.rb -t HouseOfCouncillorTest 2>&1 | grep red-datasets
```