### PR TITLE
nagoya-university-conversation-corpus: fix typo

### DIFF
--- a/lib/datasets/nagoya-university-conversation-corpus.rb
+++ b/lib/datasets/nagoya-university-conversation-corpus.rb
@@ -28,8 +28,8 @@ module Datasets
 
     def initialize
       super()
-      @metadata.id = 'nagoya-university-conversation-curpus'
-      @metadata.name = 'Nagoya University Conversation Curpus'
+      @metadata.id = 'nagoya-university-conversation-corpus'
+      @metadata.name = 'Nagoya University Conversation Corpus'
       @metadata.url = 'https://mmsrv.ninjal.ac.jp/nucc/'
       @metadata.licenses = ['CC-BY-NC-ND-4.0']
       @metadata.description = <<~DESCRIPTION


### PR DESCRIPTION
Before change:

```console
$ git grep --ignore-case curpus
lib/datasets/nagoya-university-conversation-corpus.rb:      @metadata.id = 'nagoya-university-conversation-curpus'
lib/datasets/nagoya-university-conversation-corpus.rb: @metadata.name = 'Nagoya University Conversation Curpus'
```

After change:

```console
$ git grep --ignore-case curpus
```