### PR TITLE
test nagoya-university-conversation-corpus: reduce checking

### DIFF
--- a/test/test-nagoya-university-conversation-corpus.rb
+++ b/test/test-nagoya-university-conversation-corpus.rb
@@ -7,6 +7,7 @@ class NagoyaUniversityConversationCorpusTest < Test::Unit::TestCase
     test("#sentences") do
       first_sentences = @dataset.each.next.sentences
       assert_equal([
+                     856,
                      {
                        participant_id: 'F107',
                        content: '＊＊＊の町というのはちいちゃくって、城壁がこう町全体をぐるっと回ってて、それが城壁の上を歩いても１時間ぐらいですよね。',
@@ -17,6 +18,7 @@ class NagoyaUniversityConversationCorpusTest < Test::Unit::TestCase
                      },
                    ],
                    [
+                     first_sentences.size,
                      first_sentences[0].to_h,
                      first_sentences[-1].to_h,
                    ])
@@ -25,6 +27,7 @@ class NagoyaUniversityConversationCorpusTest < Test::Unit::TestCase
     test("#participants") do
       first_participants = @dataset.each.next.participants
       assert_equal([
+                     4,
                      {
                        id: 'F107',
                        attribute: '女性３０代後半',
@@ -39,6 +42,7 @@ class NagoyaUniversityConversationCorpusTest < Test::Unit::TestCase
                      },
                    ],
                    [
+                     first_participants.size,
                      first_participants[0].to_h,
                      first_participants[-1].to_h,
                    ])

--- a/test/test-nagoya-university-conversation-corpus.rb
+++ b/test/test-nagoya-university-conversation-corpus.rb
@@ -5,116 +5,60 @@ class NagoyaUniversityConversationCorpusTest < Test::Unit::TestCase
 
   sub_test_case("each") do
     test("#sentences") do
-      records = @dataset.each.to_a
-      first_sentences = records[0].sentences
-      last_sentences = records[-1].sentences
+      first_sentences = @dataset.each.next.sentences
       assert_equal([
-                     856,
                      {
                        participant_id: 'F107',
-                       content: '＊＊＊の町というのはちいちゃくって、城壁がこう町全体をぐるっと回ってて、それが城壁の上を歩いても１時間ぐらいですよね。'
+                       content: '＊＊＊の町というのはちいちゃくって、城壁がこう町全体をぐるっと回ってて、それが城壁の上を歩いても１時間ぐらいですよね。',
                      },
                      {
                        participant_id: nil,
-                       content: nil
+                       content: nil,
                      },
-                     603,
-                     {
-                       participant_id: 'F007',
-                       content: 'それでは話を始めまーす。'
-                     },
-                     {
-                       participant_id: nil,
-                       content: nil
-                     }
                    ],
                    [
-                     first_sentences.size,
                      first_sentences[0].to_h,
                      first_sentences[-1].to_h,
-                     last_sentences.size,
-                     last_sentences[0].to_h,
-                     last_sentences[-1].to_h,
                    ])
     end
 
     test("#participants") do
-      records = @dataset.each.to_a
-      first_participants = records[0].participants
-      last_participants = records[-1].participants
+      first_participants = @dataset.each.next.participants
       assert_equal([
-                     4,
                      {
                        id: 'F107',
                        attribute: '女性３０代後半',
                        birthplace: '愛知県幡豆郡出身',
-                       residence: '愛知県幡豆郡在住'
+                       residence: '愛知県幡豆郡在住',
                      },
                      {
                        id: 'F128',
                        attribute: '女性２０代前半',
                        birthplace: '愛知県西尾市出身',
-                       residence: '西尾市在住'
+                       residence: '西尾市在住',
                      },
-                     2,
-                     {
-                       id: 'F007',
-                       attribute: '女性５０代後半',
-                       birthplace: '東京都出身',
-                       residence: '東京都国分寺市在住'
-                     },
-                     {
-                       id: 'F003',
-                       attribute: '女性８０代後半',
-                       birthplace: '栃木県宇都宮市出身',
-                       residence: '国分寺市在住'
-                     }
                    ],
                    [
-                     first_participants.size,
                      first_participants[0].to_h,
                      first_participants[-1].to_h,
-                     last_participants.size,
-                     last_participants[0].to_h,
-                     last_participants[-1].to_h
                    ])
     end
 
     test("others") do
-      records = @dataset.each.to_a
+      first_record = @dataset.each.next
       assert_equal([
-                     129,
-                     [
-                       '１（約３５分）',
-                       '２００１年１０月１６日',
-                       'ファミリーレストラン',
-                       '英会話教室の友人',
-                       nil
-                     ],
-                     [
-                       '１２９（３６分）',
-                       '２００３年２月１６日',
-                       '二人の自宅',
-                       '母と娘',
-                       'F007は東京に３８年、F003は東京に６０年居住。'
-                    ]
+                     '１（約３５分）',
+                     '２００１年１０月１６日',
+                     'ファミリーレストラン',
+                     '英会話教室の友人',
+                     nil,
                    ],
                    [
-                     records.size,
-                     [
-                       records[0].name,
-                       records[0].date,
-                       records[0].place,
-                       records[0].relationships,
-                       records[0].note
-                     ],
-                     [
-                       records[-1].name,
-                       records[-1].date,
-                       records[-1].place,
-                       records[-1].relationships,
-                       records[-1].note
-                     ]
+                     first_record.name,
+                     first_record.date,
+                     first_record.place,
+                     first_record.relationships,
+                     first_record.note,
                    ])
     end
   end


### PR DESCRIPTION
GitHub: GH-188

Because text file is too big (134,555 rows in total).

Before this change:

```console
$ time ruby test/run-test.rb -t NagoyaUniversityConversationCorpusTest --verbose=important-only
Finished in 3.65658 seconds.
4 tests, 4 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0
notifications

real    0m4.550s
user    0m3.723s
sys     0m0.568s
```

After this change:

```console
$ time ruby test/run-test.rb -t NagoyaUniversityConversationCorpusTest --verbose=important-only
Finished in 0.060458 seconds.
4 tests, 4 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0
notifications

real    0m0.613s
user    0m0.428s
sys     0m0.096s
```