### PR TITLE
japanese-date-parser: suppress "literal string will be frozen in the future" warning

### DIFF
--- a/lib/datasets/japanese-date-parser.rb
+++ b/lib/datasets/japanese-date-parser.rb
@@ -15,7 +15,7 @@ module Datasets
         match_data = Regexp.last_match
         era_initial = ERA_INITIALS[match_data[1]]
         if era_initial.nil?
-          message = "era must be one of ["
+          message = +"era must be one of ["
           message << ERA_INITIALS.keys.join(", ")
           message << "]: #{match_data[1]}"
           raise UnsupportedEraInitialRange, message


### PR DESCRIPTION
Before change:

```console
$ ruby test/run-test.rb -t JapaneseDateParserTest 2>&1 | grep red-datasets
/Users/zzz/src/github.com/red-data-tools/red-datasets/lib/datasets/japanese-date-parser.rb:19: warning: literal string will be frozen in the future
```

After change:

```console
$ ruby test/run-test.rb -t JapaneseDateParserTest 2>&1 | grep red-datasets
```