### PR TITLE
ci: remove EOL-ed Ruby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"


### PR DESCRIPTION
Because Ruby 3.0 reached EOL on 2024-04-23.

See also:
https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-0-7-released/