### PR TITLE
libsvm-dataset-list: suppress "literal string will be frozen in the future" warning

### DIFF
--- a/lib/datasets/libsvm-dataset-list.rb
+++ b/lib/datasets/libsvm-dataset-list.rb
@@ -110,7 +110,7 @@ module Datasets
           @row = []
         when "td"
           @in_td = true
-          @row << {:text => ""}
+          @row << {:text => +""}
         when "a"
           @row.last[:href] = attributes["href"] if @in_td
         end


### PR DESCRIPTION
Before change:

```console
$ ruby test/run-test.rb -t LIBSVMDatasetListTest 2>&1 | grep red-datasets
/Users/zzz/src/github.com/red-data-tools/red-datasets/lib/datasets/libsvm-dataset-list.rb:136: warning: literal string will be frozen in the future
(repeated 7 times)
```

After change:

```console
$ ruby test/run-test.rb -t LIBSVMDatasetListTest 2>&1 | grep red-datasets
```