### PR TITLE
test california-housing: reduce checking

### DIFF
--- a/test/test-california-housing.rb
+++ b/test/test-california-housing.rb
@@ -8,37 +8,18 @@ class CaliforniaHousingTest < Test::Unit::TestCase
   end
 
   test("#each") do
-    records = @dataset.each.to_a
-    assert_equal([
-                   20640,
-                   {
-                     median_house_value: 452600.000000,
-                     median_income: 8.325200,
-                     housing_median_age: 41.000000,
-                     total_rooms: 880.000000,
-                     total_bedrooms: 129.000000,
-                     population: 322.000000,
-                     households: 126.000000,
-                     latitude: 37.880000,
-                     longitude: -122.230000
-                   },
-                   {
-                     median_house_value: 89400.000000,
-                     median_income: 2.388600,
-                     housing_median_age: 16.000000,
-                     total_rooms: 2785.000000,
-                     total_bedrooms: 616.000000,
-                     population: 1387.000000,
-                     households: 530.000000,
-                     latitude: 39.370000,
-                     longitude: -121.240000
-                   },
-                 ],
-                 [
-                   records.size,
-                   records[0].to_h,
-                   records[-1].to_h
-                 ])
+    assert_equal({
+                   median_house_value: 452600.000000,
+                   median_income: 8.325200,
+                   housing_median_age: 41.000000,
+                   total_rooms: 880.000000,
+                   total_bedrooms: 129.000000,
+                   population: 322.000000,
+                   households: 126.000000,
+                   latitude: 37.880000,
+                   longitude: -122.230000,
+                 },
+                 @dataset.each.next.to_h)
   end
 
   sub_test_case("#metadata") do


### PR DESCRIPTION
GitHub: GH-188

Because csv file is too big (20,640 rows).

Before this change:

```console
$ time ruby test/run-test.rb -t CaliforniaHousingTest --verbose=important-only
Finished in 1.453959 seconds.
2 tests, 2 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0
notifications

real    0m3.029s
user    0m1.745s
sys     0m0.161s
```

After this change:

```console
$ time ruby test/run-test.rb -t CaliforniaHousingTest --verbose=important-only
Finished in 0.331599 seconds.
2 tests, 2 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0
notifications

real    0m1.126s
user    0m0.738s
sys     0m0.143s
```