### PR TITLE
test postal-code-japan: add a test for invalid reading

### DIFF
--- a/test/test-postal-code-japan.rb
+++ b/test/test-postal-code-japan.rb
@@ -1,4 +1,11 @@
 class PostalCodeJapanTest < Test::Unit::TestCase
+  test("invalid") do
+    message = ":reading must be one of [:lowercase, :uppercase, :romaji]: :invalid"
+    assert_raise(ArgumentError.new(message)) do
+      Datasets::PostalCodeJapan.new(reading: :invalid)
+    end
+  end
+
   sub_test_case(":reading") do
     test(":lowercase") do
       dataset = Datasets::PostalCodeJapan.new(reading: :lowercase)


### PR DESCRIPTION
Because verify "literal string will be frozen in the future" warning.