### PR TITLE
test sudachi-synonym-dictionary: reduce checking

### DIFF
--- a/test/test-sudachi-synonym-dictionary.rb
+++ b/test/test-sudachi-synonym-dictionary.rb
@@ -4,37 +4,18 @@ class SudachiSynonymDictionaryTest < Test::Unit::TestCase
   end
 
   test('#each') do
-    records = @dataset.each.to_a
-    assert_equal([
-                   67753,
-                   {
-                     group_id: "000001",
-                     is_noun: true,
-                     expansion_type: :always,
-                     lexeme_id: 1,
-                     form_type: :typical,
-                     acronym_type: :typical,
-                     variant_type: :typical,
-                     categories: [],
-                     notation: "曖昧",
-                   },
-                   {
-                     group_id: "026068",
-                     is_noun: true,
-                     expansion_type: :always,
-                     lexeme_id: 1,
-                     form_type: :typical,
-                     acronym_type: :others,
-                     variant_type: :typical,
-                     categories: ["IT"],
-                     notation: "サ終",
-                   },
-                 ],
-                 [
-                   records.size,
-                   records[0].to_h,
-                   records[-1].to_h,
-                 ])
+    assert_equal({
+                   group_id: "000001",
+                   is_noun: true,
+                   expansion_type: :always,
+                   lexeme_id: 1,
+                   form_type: :typical,
+                   acronym_type: :typical,
+                   variant_type: :typical,
+                   categories: [],
+                   notation: "曖昧",
+                 },
+                 @dataset.each.next.to_h)
   end
 
   sub_test_case('#metadata') do


### PR DESCRIPTION
GitHub: GH-188

Because csv file is too big (67,753 rows).

Before this change:

```console
$ time ruby test/run-test.rb -t SudachiSynonymDictionaryTest --verbose=important-only
Finished in 1.296801 seconds.
2 tests, 2 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0
notifications

real    0m1.964s
user    0m1.740s
sys     0m0.118s
```

After this change:

```console
$ time ruby test/run-test.rb -t SudachiSynonymDictionaryTest --verbose=important-only
Finished in 0.010658 seconds.
2 tests, 2 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0
notifications

real    0m0.634s
user    0m0.455s
sys     0m0.092s
```