### PR TITLE
postal-code-japan: suppress "literal string will be frozen in the future" warning

### DIFF
--- a/lib/datasets/postal-code-japan.rb
+++ b/lib/datasets/postal-code-japan.rb
@@ -41,7 +41,7 @@ module Datasets
       super()
       @reading = reading
       unless VALID_READINGS.include?(@reading)
-        message = ":reading must be one of ["
+        message = +":reading must be one of ["
         message << VALID_READINGS.collect(&:inspect).join(", ")
         message << "]: #{@reading.inspect}"
         raise ArgumentError, message


### PR DESCRIPTION
Before change:

```console
$ ruby test/run-test.rb -t PostalCodeJapanTest 2>&1 | grep red-datasets
/Users/zzz/src/github.com/red-data-tools/red-datasets/lib/datasets/postal-code-japan.rb:45: warning: literal string will be frozen in the future
```

After change:

```console
$ ruby test/run-test.rb -t PostalCodeJapanTest 2>&1 | grep red-datasets
```