### PR TITLE
test adult-test: reduce checking

### DIFF
--- a/test/test-adult.rb
+++ b/test/test-adult.rb
@@ -40,49 +40,24 @@ class AdultTest < Test::Unit::TestCase
     end
 
     test("#each") do
-      records = @dataset.each.to_a
-      assert_equal([
-                     16281,
-                     {
-                       :age => 25,
-                       :work_class => "Private",
-                       :final_weight => 226802,
-                       :education => "11th",
-                       :n_education_years => 7,
-                       :marital_status => "Never-married",
-                       :occupation => "Machine-op-inspct",
-                       :relationship => "Own-child",
-                       :race => "Black",
-                       :sex => "Male",
-                       :capital_gain => 0,
-                       :capital_loss => 0,
-                       :hours_per_week => 40,
-                       :native_country => "United-States",
-                       :label => "<=50K."
-                     },
-                     {
-                       :age => 35,
-                       :work_class => "Self-emp-inc",
-                       :final_weight => 182148,
-                       :education => "Bachelors",
-                       :n_education_years => 13,
-                       :marital_status => "Married-civ-spouse",
-                       :occupation => "Exec-managerial",
-                       :relationship => "Husband",
-                       :race => "White",
-                       :sex => "Male",
-                       :capital_gain => 0,
-                       :capital_loss => 0,
-                       :hours_per_week => 60,
-                       :native_country => "United-States",
-                       :label => ">50K."
-                     }
-                   ],
-                   [
-                     records.size,
-                     records[0].to_h,
-                     records[-1].to_h
-                   ])
+      assert_equal({
+                     :age => 25,
+                     :work_class => "Private",
+                     :final_weight => 226802,
+                     :education => "11th",
+                     :n_education_years => 7,
+                     :marital_status => "Never-married",
+                     :occupation => "Machine-op-inspct",
+                     :relationship => "Own-child",
+                     :race => "Black",
+                     :sex => "Male",
+                     :capital_gain => 0,
+                     :capital_loss => 0,
+                     :hours_per_week => 40,
+                     :native_country => "United-States",
+                     :label => "<=50K.",
+                   },
+                   @dataset.each.next.to_h)
     end
   end
 


### PR DESCRIPTION
GitHub: GH-188

Because csv file is too big (16,281 rows).

Before this change:

```console
$ time ruby test/run-test.rb -t AdultTest::test --verbose=important-only
Finished in 1.355024 seconds.
1 tests, 1 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0
notifications

real    0m1.980s
user    0m1.777s
sys     0m0.113s
```

After this change:

```console
$ time ruby test/run-test.rb -t AdultTest::test --verbose=important-only
Finished in 0.002213 seconds.
1 tests, 1 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0
notifications

real    0m0.619s
user    0m0.442s
sys     0m0.089s
```