### PR TITLE
Fix lock validation logic in downloader synchronization

### DIFF
--- a/lib/datasets/downloader.rb
+++ b/lib/datasets/downloader.rb
@@ -122,7 +122,7 @@ module Datasets
             # The process that acquired the lock will be exited before
             # it stores its process ID.
             elapsed_time = Time.now - lock_path.mtime
-            valid_lock_path = (elapsed_time > 10)
+            valid_lock_path = (elapsed_time < 10)
           else
             begin
               Process.getpgid(pid)


### PR DESCRIPTION
Correct the elapsed time comparison for lock file validation. Lock files should be considered valid when they are recent (< 10 seconds), not when they are old (> 10 seconds).

- Before: Lock files older than 10 seconds were considered valid
- After: Lock files newer than 10 seconds are considered valid

Originally suggested in a Copilot [review](https://github.com/red-data-tools/red-remote-input/pull/10#discussion_r2277833186)
